### PR TITLE
Fix broken type, add tests and formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node LTS ✨
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm ts
+      # enable this later after the project is formatted
+      # - run: pnpm quality
+      - run: pnpm test

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error",
+        "useHookAtTopLevel": "error"
+      },
+      "performance": {
+        "noBarrelFile": "off",
+        "noReExportAll": "off"
+      },
+      "style": {
+        "noDefaultExport": "off",
+        "noNegationElse": "error",
+        "useConst": "off",
+        "useExportType": "off",
+        "useImportType": "off",
+        "useTemplate": "off"
+      },
+      "suspicious": {
+        "noConsole": "off",
+        "noEmptyBlockStatements": "warn",
+        "noSkippedTests": "error",
+        "noExplicitAny": "off"
+      },
+      "a11y": {
+        "useButtonType": "off"
+      }
+    }
+  },
+  "organizeImports": {},
+  "javascript": {
+    "formatter": {
+      "semicolons": "always"
+    }
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "defaultBranch": "main",
+    "useIgnoreFile": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "scripts": {
     "test": "vitest",
     "build": "tsup",
-    "publish": "npm run build"
+    "publish": "npm run build",
+    "ts": "tsc",
+    "quality": "biome check .",
+    "quality-fix": "biome check . --write --unsafe"
   },
   "repository": {
     "type": "git",
@@ -34,15 +37,17 @@
   },
   "homepage": "https://github.com/Daanish2003/better-auth-validator#readme",
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.5",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.6"
+    "valibot": "1.0.0-rc.0",
+    "vitest": "^2.1.6",
+    "yup": "^1.4.0"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",
-    "better-auth": "^1.1.16",
-    "yup": "^1.4.0"
+    "better-auth": "^1.1.16"
   },
   "packageManager": "pnpm@10.2.1+sha512.398035c7bd696d0ba0b10a688ed558285329d27ea994804a52bad9167d8e3a72bcb993f9699585d3ca25779ac64949ef422757a6c31102c12ab932e5cbe5cc92"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,10 +14,10 @@ importers:
       better-auth:
         specifier: ^1.1.16
         version: 1.1.16
-      yup:
-        specifier: ^1.4.0
-        version: 1.5.0
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^1.9.4
+        version: 1.9.4
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.10.1)(typescript@5.7.2)
@@ -27,9 +27,15 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
+      valibot:
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0(typescript@5.7.2)
       vitest:
         specifier: ^2.1.6
         version: 2.1.8(@types/node@22.10.1)
+      yup:
+        specifier: ^1.4.0
+        version: 1.5.0
 
 packages:
 
@@ -38,6 +44,59 @@ packages:
 
   '@better-fetch/fetch@1.1.12':
     resolution: {integrity: sha512-B3bfloI/2UBQWIATRN6qmlORrvx3Mp0kkNjmXLv0b+DtbtR+pP4/I5kQA/rDUv+OReLywCCldf6co4LdDmh8JA==}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -998,6 +1057,14 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
+  valibot@1.0.0-rc.0:
+    resolution: {integrity: sha512-9ZUrOXOejY/WaIn8p0Z469R1qBAwNJeqq8jzOIDsl1qR8gqtObHQmyHLFli0UCkcGiTco5kH6/KPLWsTWE9b2g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@2.1.8:
     resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1100,6 +1167,41 @@ snapshots:
       uncrypto: 0.1.3
 
   '@better-fetch/fetch@1.1.12': {}
+
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -1902,6 +2004,10 @@ snapshots:
   undici-types@6.20.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  valibot@1.0.0-rc.0(typescript@5.7.2):
+    optionalDependencies:
+      typescript: 5.7.2
 
   vite-node@2.1.8(@types/node@22.10.1):
     dependencies:

--- a/src/core/adapters/standard-validator-adapter.ts
+++ b/src/core/adapters/standard-validator-adapter.ts
@@ -2,7 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ValidationAdapter } from '../../types';
 
 
-export const StandardAdapter: ValidationAdapter = <T extends StandardSchemaV1>(
+export const StandardAdapter: ValidationAdapter<StandardSchemaV1> = <T extends StandardSchemaV1>(
   schema: T
 ) => {
   return {

--- a/src/core/adapters/yup-adapter.ts
+++ b/src/core/adapters/yup-adapter.ts
@@ -1,6 +1,6 @@
 import * as yup from "yup";
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { ValidationAdapter, type YupStandardSchema } from "../../types";
+import type { YupValidationAdapter, YupStandardSchema } from "../../types";
 
 
 function standardizeYup<Schema extends yup.Schema>(
@@ -45,7 +45,7 @@ function standardizeYup<Schema extends yup.Schema>(
  * @summary Yup has a PR to implement standard validator. If this gets merged in then YupAdapter will be removed for the StandardAdapter
  * https://github.com/jquense/yup/pull/2258
  */
-export const YupAdapter: ValidationAdapter = <T extends yup.Schema<any>>(
+export const YupAdapter: YupValidationAdapter<yup.Schema<any>> = <T extends yup.Schema<any>>(
   schema: T
 ) => {
   const mappedSchema = standardizeYup(schema);

--- a/src/core/validator.test.ts
+++ b/src/core/validator.test.ts
@@ -1,0 +1,39 @@
+import { betterAuth } from "better-auth";
+import * as v from "valibot";
+import { describe, it } from "vitest";
+import { object, string } from "yup";
+import { StandardAdapter, YupAdapter, validator } from "../index";
+
+describe("validator", () => {
+  it("initializes without errors with valibot", () => {
+    const signupSchema = v.object({
+      name: v.string(),
+      email: v.pipe(v.string(), v.email()),
+      password: v.pipe(v.string(), v.minLength(12)),
+    });
+
+    betterAuth({
+      plugins: [
+        validator([
+          { path: "/sign-up/email", adapter: StandardAdapter(signupSchema) },
+        ]),
+      ],
+    });
+  });
+
+  it("initializes without errors with yup", () => {
+    const signupSchema = object({
+      name: string().required(),
+      email: string().email(),
+      password: string().required(),
+    });
+
+    betterAuth({
+      plugins: [
+        validator([
+          { path: "/sign-up/email", adapter: YupAdapter(signupSchema) },
+        ]),
+      ],
+    });
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,19 +25,22 @@ export type YupStandardSchema<Y extends yup.Schema<any>> = Y & {
 };
 
 
-export type ValidationAdapter = (<T extends StandardSchemaV1>(
+export type ValidationAdapter<T extends StandardSchemaV1> = (
   schema: T
 ) => {
   validate: (
     input: StandardSchemaV1.InferInput<T>
   ) => Promise<StandardSchemaV1.InferOutput<T>>;
-}) | (<T extends yup.Schema<any>>(
+};
+
+export type YupValidationAdapter<T extends yup.Schema<any>> = (
   schema: T
 ) => {
   validate: (
     input: StandardSchemaV1.InferInput<YupStandardSchema<T>>
   ) => Promise<StandardSchemaV1.InferOutput<YupStandardSchema<T>>>;
-});
+};
+
 
 
 export type ValidationConfig = {


### PR DESCRIPTION
Fixes https://github.com/Daanish2003/validation-better-auth/issues/9

This error appears
```
This expression is not callable.
  Each member of the union type 'ValidationAdapter' has signatures, but none of those signatures are compatible with each other.ts(2349)
(alias) const StandardAdapter: ValidationAdapter
```

When calling `StandardAdapter`
```ts
      validator([
        { path: "/sign-up/email", adapter: StandardAdapter(SignupSchema) },
      ]),
```

Using this schema:
```ts
import * as v from "valibot"

export const SignupSchema = v.object({
  name: v.string(),
  email: v.pipe(v.string(), v.email()),
  password: v.pipe(v.string(), v.minLength(8)),
})

export type SignupData = v.InferOutput<typeof SignupSchema>
```


The PR also adds CI automation with type checking and tests. As well as Biome for code formatting, but doesn't run them in CI yet to avoid a large diff.